### PR TITLE
Reduce max results for dev only

### DIFF
--- a/locationsearch/client/src/components/MapUtils.js
+++ b/locationsearch/client/src/components/MapUtils.js
@@ -68,7 +68,7 @@ export async function nearbySearch(latitude, longitude, radius, placeTypes) {
         radius: radius,
       },
       includedPrimaryTypes: placeTypes.length > 0 ? placeTypes : undefined,
-      maxResultCount: 20,
+      maxResultCount: 5,
       rankPreference: SearchNearbyRankPreference.POPULARITY,
     };
 


### PR DESCRIPTION
Reduce size of request for dev only b/c api costs are incurring exponentially. Currently at 30$. Development during 10/6  was 27$.