### PR TITLE
Made synonym retrieval stricter

### DIFF
--- a/locationsearch/client/src/components/GPTRequest.js
+++ b/locationsearch/client/src/components/GPTRequest.js
@@ -1,7 +1,108 @@
 import OpenAI from "openai";
 
+const KEYWORDS = new Set([
+  "accounting",
+  "airport",
+  "amusement_park",
+  "aquarium",
+  "art_gallery",
+  "atm",
+  "bakery",
+  "bank",
+  "bar",
+  "beauty_salon",
+  "bicycle_store",
+  "book_store",
+  "bowling_alley",
+  "bus_station",
+  "cafe",
+  "campground",
+  "car_dealer",
+  "car_rental",
+  "car_repair",
+  "car_wash",
+  "casino",
+  "cemetery",
+  "church",
+  "city_hall",
+  "clothing_store",
+  "convenience_store",
+  "courthouse",
+  "dentist",
+  "department_store",
+  "doctor",
+  "drugstore",
+  "electrician",
+  "electronics_store",
+  "embassy",
+  "fire_station",
+  "florist",
+  "funeral_home",
+  "furniture_store",
+  "gas_station",
+  "gym",
+  "hair_care",
+  "hardware_store",
+  "hindu_temple",
+  "home_goods_store",
+  "hospital",
+  "insurance_agency",
+  "jewelry_store",
+  "laundry",
+  "lawyer",
+  "library",
+  "light_rail_station",
+  "liquor_store",
+  "local_government_office",
+  "locksmith",
+  "lodging",
+  "meal_delivery",
+  "meal_takeaway",
+  "mosque",
+  "movie_rental",
+  "movie_theater",
+  "moving_company",
+  "museum",
+  "night_club",
+  "painter",
+  "park",
+  "parking",
+  "pet_store",
+  "pharmacy",
+  "physiotherapist",
+  "plumber",
+  "police",
+  "post_office",
+  "primary_school",
+  "real_estate_agency",
+  "restaurant",
+  "roofing_contractor",
+  "rv_park",
+  "school",
+  "secondary_school",
+  "shoe_store",
+  "shopping_mall",
+  "spa",
+  "stadium",
+  "storage",
+  "store",
+  "subway_station",
+  "supermarket",
+  "synagogue",
+  "taxi_stand",
+  "tourist_attraction",
+  "train_station",
+  "transit_station",
+  "travel_agency",
+  "university",
+  "veterinary_care",
+  "zoo",
+]);
 
-const openai = new OpenAI({ apiKey: process.env.REACT_APP_OPENAI_API_KEY, dangerouslyAllowBrowser: true });
+const openai = new OpenAI({
+  apiKey: process.env.REACT_APP_OPENAI_API_KEY,
+  dangerouslyAllowBrowser: true,
+});
 
 
 export async function getSynonyms(initWord) {
@@ -21,12 +122,16 @@ export async function getSynonyms(initWord) {
   });
 
   console.log(completion.choices[0].message);
-  completion = completion.choices[0].message.content.trim().toLowerCase();
+  completion = completion.choices[0].message.content
+                .split(" ")[0]
+                .trim()
+                .toLowerCase();
 
-  if (completion == "none") {
-    throw new Error("Failed to fit to category!");
-  } else {
+  if (KEYWORDS.has(completion)) {
+    console.log(completion);
     return completion;
+  } else {
+    return null;
   }
 }
 


### PR DESCRIPTION
If the synonym retrieval fails, either by outputting something that can't be parsed or isn't in the keywords, it will throw an error.